### PR TITLE
商品情報削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,8 +36,10 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
+    if current_user.id == item.user_id
     item.destroy
     redirect_to root_path
+    end
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
 
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     <% end %>
     <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# what
destroyのルートと設定。
コントローラーにdestroyアクションを追加。destroy実行後はルートパスへ遷移するように設定。
詳細画面の削除ボタンにパスを追加。

# why
商品削除機能実装のため。

以下動作確認用のGyazoのURLです。
https://gyazo.com/ca80d46d669eb7c1ee5a21709178a9b6
